### PR TITLE
Fix implementation of createClient parameters

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -2,13 +2,13 @@ import { createClient } from 'contentful'
 
 // Export constructor that can be used elsewhere
 export default ({
-  spaceId,
+  space,
   accessToken,
   previewAccessToken,
   environment
 }) => {
   return createClient({
-    space: spaceId,
+    space: space,
     host: previewAccessToken ? 'preview.contentful.com' : undefined,
     environment: environment || 'master',
     accessToken: previewAccessToken || accessToken


### PR DESCRIPTION
Hey @jerryjappinen,

There is a problem with your README here:
```
const cfClient = createClient({
  space,
  accessToken
})
```
-> Error: `Expected parameter space`

Turns out the option parameters are required to be like this:
```
const cfClient = createClient({
  spaceId,
  accessToken
})
```

Actually I would prefer to see the change in the implementation to match the official Contentful options.

Thanks for your work on this utility package for Contentful. I had this usecase several times now and was about to start to build something like this myself, before I discovered your package.

Best